### PR TITLE
ci: update github actions apps version to V3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout master
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
       - name: Log in to GitHub Packages
         run: echo ${GITHUB_TOKEN} | docker login -u ${GITHUB_ACTOR} --password-stdin docker.pkg.github.com
         env:
@@ -40,7 +40,7 @@ jobs:
     needs: build_backend
     steps:
       - name: Checkout master
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
       - name: Log in to GitHub Packages
         run: echo ${GITHUB_TOKEN} | docker login -u ${GITHUB_ACTOR} --password-stdin docker.pkg.github.com
         env:
@@ -85,7 +85,7 @@ jobs:
       HEROKU_REGISTRY_IMAGE: registry.heroku.com/damp-fortress-19341/improved_cloud_selection
     steps:
       - name: Checkout master
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v3
       - name: Log in to GitHub Packages
         run: echo ${GITHUB_TOKEN} | docker login -u ${GITHUB_ACTOR} --password-stdin docker.pkg.github.com
         env:
@@ -119,9 +119,9 @@ jobs:
     name: Test frontend
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 16.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
       - name: Install dependencies
@@ -146,9 +146,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: test_frontend
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 16.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
       - name: Install dependencies
@@ -167,9 +167,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test_frontend, test_backend]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 16.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
       - name: Install frontend dependencies
@@ -195,7 +195,7 @@ jobs:
         env:
           CI: true
       - name: Archive end to end screenshots
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: end-to-end-output


### PR DESCRIPTION
All these github actions apps are now to V3, cf.:
- [actions/checkout](https://github.com/actions/checkout/releases)
- [actions/setup-node](https://github.com/actions/setup-node/releases/tag/v3.0.0)
- [actions/upload-artifact](https://github.com/actions/upload-artifact/releases/tag/v3.0.0)